### PR TITLE
Remove duplicate link to Arc icon theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,6 @@ The Arc icon theme is available at https://github.com/horst3180/arc-icon-theme
 #### Arc KDE
 A port of Arc for the Plasma 5 desktop with a few additions and extras. Available [here](https://github.com/PapirusDevelopmentTeam/arc-kde).
 
-#### Arc icon theme
-The Arc icon theme is available at https://github.com/horst3180/arc-icon-theme
 
 #### Plank theme
 As of version `20180201` the plank theme will be installed along with the normal Arc-Flatabulous gtk theme. You can disable the install by passing `disable-plank` to the autogen command.


### PR DESCRIPTION
Arc icon theme is mentioned and linked to twice in the same section of the readme. This change simply removes the second entry.

---

> ### Extras
> 
> #### Arc icon theme
> The Arc icon theme is available at https://github.com/horst3180/arc-icon-theme
> 
> #### Arc KDE
> A port of Arc for the Plasma 5 desktop with a few additions and extras. Available [here](https://github.com/PapirusDevelopmentTeam/arc-kde).
> 
> #### Arc icon theme
> The Arc icon theme is available at https://github.com/horst3180/arc-icon-theme

⇩

> ### Extras
> 
> #### Arc icon theme
> The Arc icon theme is available at https://github.com/horst3180/arc-icon-theme
> 
> #### Arc KDE
> A port of Arc for the Plasma 5 desktop with a few additions and extras. Available [here](https://github.com/PapirusDevelopmentTeam/arc-kde).